### PR TITLE
Debug in VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Node: Nodemon",
+      "processId": "${command:PickProcess}",
+      "restart": true,
+      "protocol": "inspector",
+    },
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,18 @@ An easy way to get started with JavaScript on the command line. [Read more about
 * `npm install`
 * `npm start`
 * optional: include *.env* in your *.gitignore*
+
+## Debugging in VS Code
+
+Borrowed from: https://github.com/microsoft/vscode-recipes/tree/master/nodemon
+
+_Note: Debugging works best after installing and running a long running task, such as **Express** web server. VS Code automatically re-attaches to a newly spanned Node process whenever files change, but because this default console app immediately ends its process, VS Code doesn't have enough time to re-attach reliably._
+
+* Terminal:
+  * `npm run debug`
+* VS Code:
+  * Go to the Debug view and select `Node: Nodemon` configuration
+  * Start the debugger with <kbd>F5</kbd>
+  * VS Code should list all of the running node processes. Select `nodemon --exec babel-node --inspect src/index.js` 
+![image](https://user-images.githubusercontent.com/504505/77853652-0c17a580-719a-11ea-88f1-4fc02ddd568c.png)
+  * Set a breakpoint and it should now be hit

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon --exec babel-node src/index.js",
-    "test": "echo \"No test specified\" && exit 0"
+    "test": "echo \"No test specified\" && exit 0",
+    "debug": "nodemon --exec babel-node --inspect src/index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Add configuration and instructions to run debugger in VS Code.

With these changes, you will be able to run:
* `npm run debug` in Terminal
* <kbd>F5</kbd> in VS Code
...and breakpoints will now be hit.